### PR TITLE
Postgres 9.6 compatibility

### DIFF
--- a/sql/pgq/triggers/stringutil.c
+++ b/sql/pgq/triggers/stringutil.c
@@ -17,10 +17,16 @@
  */
 
 #include <postgres.h>
+#include <catalog/catversion.h>
 #include <lib/stringinfo.h>
 #include <mb/pg_wchar.h>
-#include <parser/keywords.h>
 #include <utils/memutils.h>
+
+#if CATALOG_VERSION_NO >= 201603211
+    #include <common/keywords.h>
+#else
+    #include <parser/keywords.h>
+#endif
 
 #include "stringutil.h"
 


### PR DESCRIPTION
Change in Postgres codebase: 
https://github.com/postgres/postgres/commit/2c6af4f44228d76d3351fe26f68b00b55cdd239a

breaks the londiste build, as `keywords.h` has been moved from `parser` directory to `common` directory. We can use `CATALOG_VERSION_NO>=201603211` to detect the correct location of `keywords.h` and include it.

`CATALOG_VERSION_NO` value related to this commit is defined here:
https://github.com/postgres/postgres/blob/2c6af4f44228d76d3351fe26f68b00b55cdd239a/src/include/catalog/catversion.h
